### PR TITLE
Fix login options declaration mix-up

### DIFF
--- a/src/ILoginInputOptions.ts
+++ b/src/ILoginInputOptions.ts
@@ -30,26 +30,26 @@ type ILoginInputOptions =
   | (IWebIdLoginInputOptions & IPopupLoginInputOptions);
 export default ILoginInputOptions;
 
-export interface ICoreLoginInuptOptions {
+export interface ICoreLoginInputOptions {
   state?: string;
   clientId?: string;
   doNotAutoRedirect?: boolean;
   clientName?: string;
 }
 
-export interface IWebIdLoginInputOptions extends ICoreLoginInuptOptions {
+export interface IWebIdLoginInputOptions extends ICoreLoginInputOptions {
   webId: string;
 }
 
-export interface IIssuerLoginInputOptions extends ICoreLoginInuptOptions {
+export interface IIssuerLoginInputOptions extends ICoreLoginInputOptions {
   oidcIssuer: string;
 }
 
-export interface IRedirectLoginInputOptions extends ICoreLoginInuptOptions {
+export interface IRedirectLoginInputOptions extends ICoreLoginInputOptions {
   redirect: string;
 }
 
-export interface IPopupLoginInputOptions extends ICoreLoginInuptOptions {
+export interface IPopupLoginInputOptions extends ICoreLoginInputOptions {
   popUp: boolean;
   popUpRedirectPath: string;
 }

--- a/src/ILoginInputOptions.ts
+++ b/src/ILoginInputOptions.ts
@@ -37,11 +37,11 @@ export interface ICoreLoginInuptOptions {
   clientName?: string;
 }
 
-export interface IIssuerLoginInputOptions extends ICoreLoginInuptOptions {
+export interface IWebIdLoginInputOptions extends ICoreLoginInuptOptions {
   webId: string;
 }
 
-export interface IWebIdLoginInputOptions extends ICoreLoginInuptOptions {
+export interface IIssuerLoginInputOptions extends ICoreLoginInuptOptions {
   oidcIssuer: string;
 }
 


### PR DESCRIPTION
This is a silly fix, but it can potentially break existing applications relying on types. So maybe this should be held up until a release with other breaking changes.