### PR TITLE
Fix broken dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "crypto-random-string": "^3.3.0",
     "debug": "^4.3.1",
     "eslint-plugin-license-header": "^0.2.0",
-    "form-urlencoded": "^4.1.4",
+    "form-urlencoded": "^6.0.4",
     "husky": "^4.2.3",
     "jose": "^1.27.2",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
We had form-urlencoded 4.1.4.  Later versions in the 4 series e.g. 4.5.1 broke solid-auth-fetcher.'s nodejs login.  Form-urlencoded has gone through some er, changes - bumped to version 5, then 6 in the past month.  The latest, 6.0.4 works with solid-auth-fetcher.  This should resolve https://github.com/solid/solid-auth-fetcher/issues/25
